### PR TITLE
Filtering PodList results by deployment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Useful for deploy bots.
 
 Includes `main.go` sample app demonstrates its features.
 
-Tested with Go 1.10
-
 [![Build Status](https://travis-ci.org/Unity-Technologies/kubernetes-deploy.png?branch=master)](https://travis-ci.org/Unity-Technologies/kubernetes-deploy)
 
 # How does it work?

--- a/deploy/podlist.go
+++ b/deploy/podlist.go
@@ -39,6 +39,21 @@ func (p *PodList) Overview() []PodItem {
 	return metadata
 }
 
+// FilterByDeployment returns a new PodList with only deployment names that match prefix.
+// Handy for only retrieving specific deployment when running multiple deployments in same namespace.
+func (p *PodList) FilterByDeployment(namePrefix string) *PodList {
+	pods := []PodMetadataContainer{}
+
+	for _, item := range p.Items {
+		if strings.HasPrefix(item.Metadata.Name, namePrefix) {
+			pods = append(pods, item)
+		}
+	}
+	return &PodList{
+		Items: pods,
+	}
+}
+
 // formatPodImage converts a full pod image name into only the docker image and commit hash
 func formatPodImage(raw string) (result string) {
 	s := strings.Split(raw, ":")

--- a/deploy/podlist_test.go
+++ b/deploy/podlist_test.go
@@ -69,6 +69,29 @@ func TestPodListNoContainerStatus(t *testing.T) {
 	assert.Equal(t, timestamp, pod.Created)
 }
 
+func TestPodListFilterByDeployment_WithMatch(t *testing.T) {
+	clusterNamespace := &KubernetesClusterNamespace{
+		PodRetriever: &MockPodListWithoutContainerStatuses{},
+	}
+
+	podList, _ := clusterNamespace.GetPodList()
+
+	filteredPodList := podList.FilterByDeployment("myapp-deployment")
+	pod := filteredPodList.Items[0]
+	assert.Equal(t, "myapp-deployment-1376141578-9q2hx", pod.Metadata.Name)
+}
+
+func TestPodListFilterByDeployment_NoMatch(t *testing.T) {
+	clusterNamespace := &KubernetesClusterNamespace{
+		PodRetriever: &MockPodListWithoutContainerStatuses{},
+	}
+
+	podList, _ := clusterNamespace.GetPodList()
+
+	filteredPodList := podList.FilterByDeployment("unknown-deployment")
+	assert.Equal(t, 0, len(filteredPodList.Items))
+}
+
 //
 // MOCK DATA
 //


### PR DESCRIPTION
When running more than one deployment in the same Kubernetes namespace `PodList` was bringing back more pods than desired.

This PR adds a function to filter `PodList` by its deployment name so downstream apps can just pull out the deployments desired.